### PR TITLE
Exclude node_modules from webpack build

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,3 @@
-var webpack = require('webpack')
 var path = require('path');
 
 module.exports = function(config) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 var webpack = require('webpack')
-
+var path = require('path');
 
 module.exports = function(config) {
   config.set({
@@ -22,6 +22,7 @@ module.exports = function(config) {
           {
             test: /\.js$/,
             loader: 'babel',
+            exclude: path.resolve(__dirname, 'node_modules'),
             query: {
               presets: ['airbnb']
             }


### PR DESCRIPTION
Chai will complain if node_modules is included due to strict mode being applied.  Also, excluding speeds the build time.