### PR TITLE
Update webpack config to allow render

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,6 @@
+var webpack = require('webpack')
+
+
 module.exports = function(config) {
   config.set({
     basePath: '',
@@ -22,11 +25,14 @@ module.exports = function(config) {
             query: {
               presets: ['airbnb']
             }
-          }
+          },
+          {
+            test: /\.json$/,
+            loader: 'json',
+          },
         ]
       },
       externals: {
-        'cheerio': 'window',
         'react/lib/ExecutionEnvironment': true,
         'react/lib/ReactContext': true
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "chai": "^3.5.0",
     "enzyme": "^2.0.0-rc1",
     "jasmine-core": "^2.4.1",
+    "json-loader": "^0.5.4",
     "karma": "^0.13.19",
     "karma-babel-preprocessor": "^6.0.1",
     "karma-browserify": "^5.0.0",

--- a/test/Foo-test.js
+++ b/test/Foo-test.js
@@ -14,4 +14,8 @@ describe("A suite", function() {
   it("contains spec with an expectation", function() {
     expect(mount(<Foo />).find('.foo').length).toBe(1);
   });
+
+  it("can run an expectation with render", function() {
+    expect(render(<Foo />).find('.foo').length).toBe(1);
+  });
 });


### PR DESCRIPTION
Fix enzyme render to work with webpack.  Updates to the webpack config thanks to @lecstor suggestion in from airbnb/enzyme#47